### PR TITLE
Fix whisper-rs hash mismatch and add elegant hash management

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -57,21 +57,60 @@
       # Basic modules (will use rustPlatform)
       home-manager = ./packaging/nixos/home-manager.nix;
       nixos = ./packaging/nixos/nixos.nix;
-      
+
       # Pre-configured modules with crane support
       # These can be used directly: imports = [ whisp-away.nixosModules.home-manager-with-crane ];
       home-manager-with-crane = { config, lib, pkgs, ... }: {
         imports = [ ./packaging/nixos/home-manager.nix ];
         _module.args.craneLib = craneLib;
       };
-      
+
       nixos-with-crane = { config, lib, pkgs, ... }: {
         imports = [ ./packaging/nixos/nixos.nix ];
         _module.args.craneLib = craneLib;
       };
     };
-    
-    # Example configurations can be added here if needed
-    # nixosConfigurations = { };
+
+    apps.${system} = {
+      update-git-deps = {
+        type = "app";
+        program = "${pkgs.writeShellScript "update-git-deps" ''
+          set -euo pipefail
+
+          echo "Updating git dependency hashes from Cargo.lock..."
+
+          # Parse Cargo.lock for whisper-rs
+          REV=$(${pkgs.gnugrep}/bin/grep -A2 'name = "whisper-rs"' Cargo.lock | \
+                ${pkgs.gnugrep}/bin/grep -oP '#\K[a-f0-9]+' | head -1)
+
+          if [ -z "$REV" ]; then
+            echo "Error: Could not find whisper-rs in Cargo.lock"
+            exit 1
+          fi
+
+          echo "Found whisper-rs rev: $REV"
+          echo "Fetching hash..."
+
+          HASH=$(${pkgs.nix-prefetch-git}/bin/nix-prefetch-git \
+            https://codeberg.org/madjinn/whisper-rs.git \
+            --rev "$REV" --quiet 2>/dev/null | ${pkgs.jq}/bin/jq -r .hash)
+
+          echo "Hash: $HASH"
+
+          # Update git-deps.nix
+          cat > git-deps.nix <<EOF
+          # Git dependency hashes
+          # Update with: nix run .#update-git-deps
+          {
+            "whisper-rs" = "$HASH";
+          }
+          EOF
+
+          echo "✓ Updated git-deps.nix"
+        ''}";
+      };
+
+      default = self.apps.${system}.update-git-deps;
+    };
   };
 }

--- a/git-deps.nix
+++ b/git-deps.nix
@@ -1,0 +1,5 @@
+# Git dependency hashes
+# Update with: nix run .#update-git-deps
+{
+  "whisper-rs" = "sha256-jvSNc9SGiFpJbx9uJY4KF+TYa63YVhvA4gFngLLQp/0=";
+}


### PR DESCRIPTION
- Update whisper-rs hash to correct value
- Parse Cargo.lock automatically to extract git rev
- Store only hash in git-deps.nix (rev is source of truth in Cargo.lock)
- Add 'nix run .#update-git-deps' command to update hashes

(PSA: Vibecoded)