### PR TITLE
fix(daemon): properly close socket connections after responding

### DIFF
--- a/src/whisper_cpp/daemon.rs
+++ b/src/whisper_cpp/daemon.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::{Read, Write};
 use std::os::unix::net::{UnixListener, UnixStream};
+use std::net::Shutdown;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::sync::Arc;
@@ -205,6 +206,8 @@ async fn handle_connection(
         };
         let response_json = serde_json::to_string(&response)?;
         stream.write_all(response_json.as_bytes())?;
+        stream.flush()?;
+        stream.shutdown(Shutdown::Both)?;
         return Ok(());
     }
     
@@ -219,6 +222,8 @@ async fn handle_connection(
         };
         let response_json = serde_json::to_string(&response)?;
         stream.write_all(response_json.as_bytes())?;
+        stream.flush()?;
+        stream.shutdown(Shutdown::Both)?;
         return Ok(());
     }
     
@@ -234,7 +239,9 @@ async fn handle_connection(
     
     let response_json = serde_json::to_string(&response)?;
     stream.write_all(response_json.as_bytes())?;
-    
+    stream.flush()?;
+    stream.shutdown(Shutdown::Both)?;
+
     Ok(())
 }
 
@@ -263,6 +270,8 @@ async fn handle_connection_with_state(
         };
         let response_json = serde_json::to_string(&response)?;
         stream.write_all(response_json.as_bytes())?;
+        stream.flush()?;
+        stream.shutdown(Shutdown::Both)?;
         return Ok(());
     }
     
@@ -277,6 +286,8 @@ async fn handle_connection_with_state(
         };
         let response_json = serde_json::to_string(&response)?;
         stream.write_all(response_json.as_bytes())?;
+        stream.flush()?;
+        stream.shutdown(Shutdown::Both)?;
         return Ok(());
     }
     
@@ -292,7 +303,9 @@ async fn handle_connection_with_state(
     
     let response_json = serde_json::to_string(&response)?;
     stream.write_all(response_json.as_bytes())?;
-    
+    stream.flush()?;
+    stream.shutdown(Shutdown::Both)?;
+
     Ok(())
 }
 


### PR DESCRIPTION
## Problem

The daemon does not explicitly close socket connections after sending responses. This causes clients (e.g., using `socat`) to wait for their configured timeout instead of receiving EOF immediately.

For example, with `socat -t120`, clients wait 120 seconds after receiving the response because the daemon never signals connection close.

## Root Cause

Simply dropping the `UnixStream` in Rust does not guarantee an immediate EOF signal to the peer. The OS may delay or batch the connection teardown.

## Fix

After writing the response, explicitly:
1. `stream.flush()` - ensure all data is sent
2. `stream.shutdown(Shutdown::Both)` - signal connection close to peer

## Changes

- Added `use std::net::Shutdown;` import
- Added `flush()` and `shutdown()` calls after all `write_all()` calls in `handle_connection` and `handle_connection_with_state` functions

## Testing

Before: Client waits for full timeout after response received
After: Client receives EOF immediately, returns response instantly