### PR TITLE
fix(nixos): LD_LIBRARY_PATH set incorrectly

### DIFF
--- a/packaging/nixos/nixos.nix
+++ b/packaging/nixos/nixos.nix
@@ -97,7 +97,10 @@ in {
       WA_USE_CLIPBOARD = if cfg.useClipboard then "true" else "false";
     } // optionalAttrs (cfg.accelerationType == "cuda") {
       CUDA_VISIBLE_DEVICES = "0";
-      LD_LIBRARY_PATH = "${pkgs.cudaPackages.cudatoolkit}/lib:${pkgs.cudaPackages.cudnn}/lib:\${LD_LIBRARY_PATH}";
+      LD_LIBRARY_PATH = [
+        "${pkgs.cudaPackages.cudatoolkit}/lib"
+        "${pkgs.cudaPackages.cudnn}/lib"
+      ];
     };
     
     # Create cache directories using systemd tmpfiles


### PR DESCRIPTION
In NixOS now, `LD_LIBRARY_PATH` is supposed to be set as a nix list of path strings, not one big string containing multiple paths separated by colons. Without this patch, the NixOS module does not build.