### PR TITLE
fix(flake): crane input version not pinned like its readme recommends

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    crane.url = "github:ipetkov/crane";
+    crane.url = "github:ipetkov/crane/v0.23.4";
   };
 
   outputs = { self, nixpkgs, crane, ... }@inputs:


### PR DESCRIPTION
Crane's readme states:

> ## Compatibility Policy
>
> Breaking changes can land on the `master` branch at any time, so it is recommended you use a versioning strategy when consuming this library (for example, using something like flakes or [niv](https://github.com/nmattia/niv)).
> 
> Tagged releases will be cut periodically and changes will be documented in the [CHANGELOG](https://github.com/ipetkov/crane/blob/master/CHANGELOG.md). Release versions will follow [Semantic Versioning](http://semver.org/spec/v2.0.0.html).

So this patch pins the crane input to its latest stable release.